### PR TITLE
uses `--matching` option instead of `--filter`

### DIFF
--- a/foundation_remapping.lua
+++ b/foundation_remapping.lua
@@ -276,6 +276,7 @@ local CFundationRemapImpl = {
         if cmd then
             if os.execute(cmd) ~= true then
                 log.d('error occured while register()')
+                log.d('command:' .. cmd)
             end
         end
         return self
@@ -286,6 +287,7 @@ local CFundationRemapImpl = {
         if cmd then
             if os.execute(cmd) ~= true then
                 log.d('error occured while unregister()')
+                log.d('command:' .. cmd)
             end
         end
         return self

--- a/foundation_remapping.lua
+++ b/foundation_remapping.lua
@@ -236,8 +236,12 @@ local CFundationRemapImpl = {
         if self.vendorID then
             filter = filter .. '"VendorID":' .. self.vendorID .. ','
         end
+        local optionName = '--filter'
+        if os.execute("hidutil property --help | grep -e '--matching'") then
+            optionName = '--matching'
+        end
         if #filter > 0 then
-            return ' --filter \'{' .. filter .. '}\''
+            return ' ' .. optionName .. ' \'{' .. filter .. '}\''
         end
         return ''
     end,

--- a/foundation_remapping.lua
+++ b/foundation_remapping.lua
@@ -129,7 +129,7 @@ CFundationRemap.hidkeys = {
     f21=0x70,  f22=0x71,  f23=0x72,  f24=0x73,
     Execute=0x74,
     -- [0x72] = 0x75, --help conflict with insert
-    Menu=0x76, Select=0x77, Stop=0x78, Again=0x79, Undo=0x7a, Cut=0x7b, Copy=0x7c, Paste=0x7d, Find=0x7e, 
+    Menu=0x76, Select=0x77, Stop=0x78, Again=0x79, Undo=0x7a, Cut=0x7b, Copy=0x7c, Paste=0x7d, Find=0x7e,
     [0x4a] = 0x7f, -- Norsi Mute, or maybe 0x4a
     [0x48] = 0x80, -- Norsi volume up, otherwise is 0x48 in ADB
     [0x49] = 0x81, -- Norsi volume down
@@ -160,7 +160,7 @@ CFundationRemap.hidkeys = {
     [0x38] = 0xe1, lshift = 0xe1, --Left Shift
     [0x3a] = 0xe2, lalt = 0xe2, lopt = 0xe2, --Left option/alt key
     [0x37] = 0xe3, lcmd = 0xe3,--Left command key
-    [0x3e] = 0xe4, rctrl = 0xe4, rctl = 0xe4, --Right Control, use 0x3e virtual 
+    [0x3e] = 0xe4, rctrl = 0xe4, rctl = 0xe4, --Right Control, use 0x3e virtual
     [0x3c] = 0xe5, rshift = 0xe5, --Right Shift, use 0x3c virtual
     [0x3d] = 0xe6, ralt = 0xe6, ropt = 0xe6, --Right Option, use 0x3d virtual
     [0x36] = 0xe7, rcmd = 0xe7, --Right Command, use 0x36 virtual
@@ -197,7 +197,7 @@ local function hidKeyCode(keyCode)
             return hidCode
         end
     end
-    
+
     keyCode = realKeyCode(keyCode)
     if keyCode ~= nil then
         --数値keyCodeで探す


### PR DESCRIPTION
I'm using macOS Mojave 10.14.1, and its `hidutil` doesn't support the `--filter` option. Apparently, it got renamed to `--matching`. I tried to find some documentation about this change and couldn't.

The change here, hopefully, is backwards compatible. I can't test it though.

This is the output of `hidutil property --help` on my machine:

```
Read/Write HID Event System property

Usage:

  hidutil property [ --matching <matching> ][ --get <key> ][ --set <key> ]

Flags:

  -g  --get...................Get property with key (where key is string value)
  -s  --set...................Set property (key/value pair JSON style dictionary)
  -m  --matching..............Set matching services/devices
                              Input can be either json style dictionary or common
                              device string e.g. keyboard, mouse, digitizer.
                                  Supported properties:
                                      ProductID        - numeric value (decimal or hex)
                                      VendorID         - numeric value (decimal or hex)
                                      LocationID       - numeric value (decimal or hex)
                                      PrimaryUsagePage - numeric value (decimal or hex)
                                      PrimaryUsage     - numeric value (decimal or hex)
                                      Transport        - string value
                                      Product          - string value
                                  For matching against generic properties, you will need to include
                                  the "IOPropertyMatch" key (see example below).
                                  Example strings:
                                      'keyboard'
                                      'digi'
                                      '{"ProductID":0x8600,"VendorID":0x5ac}'
                                      '[{"ProductID":0x8600},{"PrimaryUsagePage":1,"PrimaryUsage":6}]'
                                      '{"IOPropertyMatch":{"ReportInterval":1000}}'

Examples:

  hidutil property --matching '{"ProductID":0x54c}' --get "HIDPointerAcceleration"
  hidutil property --matching '{"ProductID":0x54c,"VendorID":746}' --set '{"HIDPointerAcceleration":0}'
  hidutil property --get "HIDPointerAcceleration"
```